### PR TITLE
Bugfix/polar param

### DIFF
--- a/src/Base/ren_params.jl
+++ b/src/Base/ren_params.jl
@@ -62,6 +62,7 @@ mutable struct DirectRENParams{T}
     polar_param::Bool                   # Whether or not to use polar parameterisation
     D22_free   ::Bool                   # Is D22 free or parameterised by (X3,Y3,Z3)?
     D22_zero   ::Bool                   # Option to remove feedthrough.
+    is_output  ::Bool
 end
 
 """
@@ -93,6 +94,8 @@ This is typically used by higher-level constructors when defining a REN, which t
 
 - `bv_scale::T=1`: Set scalse of initial neuron input bias vector `bv`.
 
+- `is_output::Bool=true`: Include output layer ``y_t = C_2 x_t + D_{21} w_t + D_{22} u_t + b_y``.
+
 - `ϵ::T=1e-12`: Regularising parameter for positive-definite matrices.
 
 - `rng::AbstractRNG=Random.GLOBAL_RNG`: rng for model initialisation.
@@ -103,20 +106,29 @@ See also [`GeneralRENParams`](@ref), [`ContractingRENParams`](@ref), [`Lipschitz
 """
 function DirectRENParams{T}(
     nu::Int, nx::Int, nv::Int, ny::Int; 
-    init = :random,
-    polar_param::Bool = true,
-    D22_free::Bool = false,
-    D22_zero::Bool = false,
-    bx_scale::T = T(0), 
-    bv_scale::T = T(1), 
-    ϵ::T = T(1e-12), 
-    rng::AbstractRNG = Random.GLOBAL_RNG
+    init                = :random,
+    polar_param::Bool   = true,
+    D22_free::Bool      = false,
+    D22_zero::Bool      = false,
+    bx_scale::T         = T(0), 
+    bv_scale::T         = T(1), 
+    is_output::Bool     = true,
+    ϵ::T                = T(1e-12), 
+    rng::AbstractRNG    = Random.GLOBAL_RNG
 ) where T
 
     # Check options
     if D22_zero
         @warn """Setting D22 fixed at 0. Removing feedthrough."""
         D22_free = true
+    end
+    if !is_output
+        D22_zero = true
+        D22_free = true
+        if nx != ny
+            @warn """Requested no output layer (identity). Setting `ny = nx`, setting D22 fixed at 0."""
+            ny = nx
+        end
     end
 
     # Random sampling
@@ -163,9 +175,15 @@ function DirectRENParams{T}(
     Y1 = glorot_normal(nx, nx; T=T, rng=rng)
 
     # Output layer
-    C2  = glorot_normal(ny,nx; rng=rng)
-    D21 = glorot_normal(ny,nv; rng=rng)
-    D22 = zeros(T, ny, nu)
+    if is_output
+        C2  = glorot_normal(ny,nx; rng=rng)
+        D21 = glorot_normal(ny,nv; rng=rng)
+        D22 = zeros(T, ny, nu)
+    else
+        C2  = Matrix{T}(I, nx, nx)
+        D21 = zeros(T, ny, nv)
+        D22 = zeros(T, ny, nu)
+    end
 
     # Parameters for D22 in output layer
     if D22_free
@@ -182,15 +200,16 @@ function DirectRENParams{T}(
     # Bias terms
     bv = T(bv_scale) * glorot_normal(nv; T=T, rng=rng)
     bx = T(bx_scale) * glorot_normal(nx; T=T, rng=rng)
-    by = glorot_normal(ny; rng=rng)
+    by = is_output ? glorot_normal(ny; rng=rng) : zeros(T, ny)
 
     return DirectRENParams(
         X, 
         Y1, X3, Y3, Z3, 
         B2, C2, D12, D21, D22,
         bx, bv, by, T(ϵ), ρ,
-        polar_param, D22_free, D22_zero
-)
+        polar_param, D22_free, D22_zero,
+        is_output
+    )
 end
 
 Flux.@functor DirectRENParams
@@ -198,7 +217,9 @@ Flux.@functor DirectRENParams
 function Flux.trainable(m::DirectRENParams)
 
     # Field names of trainable params, exclude ρ if needed
-    if m.D22_free
+    if !m.is_output
+        fs = [:X, :Y1, :B2, :D12, :bx, :bv, :ρ]
+    elseif m.D22_free
         if m.D22_zero
             fs = [:X, :Y1, :B2, :C2, :D12, :D21, :bx, :bv, :by, :ρ]
         else

--- a/src/Base/ren_params.jl
+++ b/src/Base/ren_params.jl
@@ -157,7 +157,7 @@ function DirectRENParams{T}(
     end
 
     # Polar parameter
-    ρ = polar_param ? [norm(X)] : zeros(T,0)
+    ρ = [norm(X)]
 
     # Free parameter for E
     Y1 = glorot_normal(nx, nx; T=T, rng=rng)

--- a/src/ParameterTypes/contracting_ren.jl
+++ b/src/ParameterTypes/contracting_ren.jl
@@ -27,21 +27,22 @@ The parameters can be used to construct an explicit [`REN`](@ref) model that has
 
 - `αbar::T=1`: Upper bound on the contraction rate with `ᾱ ∈ (0,1]`.
 
-See [`DirectRENParams`](@ref) for documentation of keyword arguments `init`, `ϵ`, `bx_scale`, `bv_scale`, `polar_param`, `D22_zero`, `rng`.
+See [`DirectRENParams`](@ref) for documentation of keyword arguments `init`, `ϵ`, `bx_scale`, `bv_scale`, `polar_param`, `D22_zero`, `is_output`, `rng`.
 
 See also [`GeneralRENParams`](@ref), [`LipschitzRENParams`](@ref), [`PassiveRENParams`](@ref).
 """
 function ContractingRENParams{T}(
     nu::Int, nx::Int, nv::Int, ny::Int;
-    nl::Function = Flux.relu, 
-    αbar::T = T(1),
-    init = :random,
-    polar_param::Bool = true,
-    D22_zero::Bool = false,
-    bx_scale::T = T(0), 
-    bv_scale::T = T(1), 
-    ϵ::T = T(1e-12), 
-    rng::AbstractRNG = Random.GLOBAL_RNG
+    nl::Function        = Flux.relu, 
+    αbar::T             = T(1),
+    init                = :random,
+    polar_param::Bool   = true,
+    D22_zero::Bool      = false,
+    bx_scale::T         = T(0), 
+    bv_scale::T         = T(1), 
+    is_output::Bool     = true,
+    ϵ::T                = T(1e-12), 
+    rng::AbstractRNG    = Random.GLOBAL_RNG
 ) where T
 
     # Direct (implicit) params
@@ -49,7 +50,7 @@ function ContractingRENParams{T}(
         nu, nx, nv, ny; 
         init=init, ϵ=ϵ, bx_scale=bx_scale, bv_scale=bv_scale, 
         polar_param=polar_param, D22_free=true, D22_zero=D22_zero,
-        rng=rng
+        is_output=is_output, rng=rng
     )
 
     return ContractingRENParams{T}(nl, nu, nx, nv, ny, direct_ps, αbar)

--- a/test/ParameterTypes/contraction.jl
+++ b/test/ParameterTypes/contraction.jl
@@ -5,13 +5,18 @@ using Test
 # include("../test_utils.jl")
 
 """
-Test that the contracting REN actually does contract
+Test that the contracting REN actually does contract.
+
+Test uses some of the additional options just to double-check.
 """
 batches = 42
-nu, nx, nv, ny = 4, 5, 10, 2
+nu, nx, nv, ny = 4, 5, 10, 5
 ᾱ = 0.5
 
-ren_ps = ContractingRENParams{Float64}(nu, nx, nv, ny; init=:cholesky, αbar=ᾱ)
+ren_ps = ContractingRENParams{Float64}(
+    nu, nx, nv, ny; 
+    init=:cholesky, αbar=ᾱ, polar_param=false, is_output=false
+)
 ren = REN(ren_ps)
 
 # Same inputs. different initial conditions


### PR DESCRIPTION
- Fixed a bug when choosing not to use the polar parameterisation.
- Added functionality to have a contracting REN with no output layer.