### PR TITLE
License file reference in all source files

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using Documenter
 using RobustNeuralNetworks
 

--- a/examples/src/contracting_ren.jl
+++ b/examples/src/contracting_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 cd(@__DIR__)
 using Pkg
 Pkg.activate("../")

--- a/examples/src/echo_ren.jl
+++ b/examples/src/echo_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 cd(@__DIR__)
 using Pkg
 Pkg.activate("../")

--- a/examples/src/lbdn_curvefit.jl
+++ b/examples/src/lbdn_curvefit.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 cd(@__DIR__)
 using Pkg
 Pkg.activate("../")

--- a/examples/src/lbdn_mnist.jl
+++ b/examples/src/lbdn_mnist.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 cd(@__DIR__)
 using Pkg
 Pkg.activate("../")

--- a/examples/src/lbdn_rl.jl
+++ b/examples/src/lbdn_rl.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 cd(@__DIR__)
 using Pkg
 Pkg.activate("..")

--- a/examples/src/ren_pde_obsv.jl
+++ b/examples/src/ren_pde_obsv.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 cd(@__DIR__)
 using Pkg
 Pkg.activate("..")

--- a/src/Base/acyclic_ren_solver.jl
+++ b/src/Base/acyclic_ren_solver.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 """
     solve_tril_layer(ϕ, W::Matrix, b::VecOrMat)
 

--- a/src/Base/lbdn_params.jl
+++ b/src/Base/lbdn_params.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 """
     mutable struct ExplicitLBDNParams{T, N, M}
 

--- a/src/Base/ren_params.jl
+++ b/src/Base/ren_params.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 @doc raw"""
     mutable struct ExplicitRENParams{T}
 

--- a/src/Base/utils.jl
+++ b/src/Base/utils.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 """
     glorot_normal(n::Int, m::Int; T=Float64, rng=Random.GLOBAL_RNG)
 

--- a/src/ParameterTypes/contracting_ren.jl
+++ b/src/ParameterTypes/contracting_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct ContractingRENParams{T} <: AbstractRENParams{T}
     nl::Function                # Sector-bounded nonlinearity
     nu::Int

--- a/src/ParameterTypes/dense_lbdn.jl
+++ b/src/ParameterTypes/dense_lbdn.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct DenseLBDNParams{T} <: AbstractLBDNParams{T}
     nl::Function                    # Sector-bounded nonlinearity
     nu::Int

--- a/src/ParameterTypes/general_ren.jl
+++ b/src/ParameterTypes/general_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct GeneralRENParams{T} <: AbstractRENParams{T}
     nl::Function                # Sector-bounded nonlinearity
     nu::Int

--- a/src/ParameterTypes/lipschitz_ren.jl
+++ b/src/ParameterTypes/lipschitz_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct LipschitzRENParams{T} <: AbstractRENParams{T}
     nl::Function                # Sector-bounded nonlinearity
     nu::Int

--- a/src/ParameterTypes/passive_ren.jl
+++ b/src/ParameterTypes/passive_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct PassiveRENParams{T} <: AbstractRENParams{T}
     nl::Function                # Sector-bounded nonlinearity
     nu::Int

--- a/src/ParameterTypes/utils.jl
+++ b/src/ParameterTypes/utils.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 """
     direct_to_explicit(ps::AbstractRENParams{T}, return_h=false) where T
 

--- a/src/RobustNeuralNetworks.jl
+++ b/src/RobustNeuralNetworks.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 module RobustNeuralNetworks
 
 ############ Package dependencies ############

--- a/src/Wrappers/LBDN/diff_lbdn.jl
+++ b/src/Wrappers/LBDN/diff_lbdn.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct DiffLBDN{T} <: AbstractLBDN{T}
     nl::Function
     nu::Int

--- a/src/Wrappers/LBDN/lbdn.jl
+++ b/src/Wrappers/LBDN/lbdn.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct LBDN{T} <: AbstractLBDN{T}
     nl::Function
     nu::Int

--- a/src/Wrappers/LBDN/sandwich_fc.jl
+++ b/src/Wrappers/LBDN/sandwich_fc.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct SandwichFC{F, T, D, B}
     σ ::F
     XY::AbstractMatrix{T}       # [X; Y] in the paper

--- a/src/Wrappers/REN/diff_ren.jl
+++ b/src/Wrappers/REN/diff_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct DiffREN{T} <: AbstractREN{T}
     nl::Function
     nu::Int

--- a/src/Wrappers/REN/ren.jl
+++ b/src/Wrappers/REN/ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct REN{T} <: AbstractREN{T}
     nl::Function
     nu::Int

--- a/src/Wrappers/REN/wrap_ren.jl
+++ b/src/Wrappers/REN/wrap_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 mutable struct WrapREN{T} <: AbstractREN{T}
     nl::Function
     nu::Int

--- a/test/ParameterTypes/contraction.jl
+++ b/test/ParameterTypes/contraction.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using Random
 using RobustNeuralNetworks
 using Test

--- a/test/ParameterTypes/dense_lbdn.jl
+++ b/test/ParameterTypes/dense_lbdn.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using Random
 using RobustNeuralNetworks
 using Test

--- a/test/ParameterTypes/general_behavioural_constrains.jl
+++ b/test/ParameterTypes/general_behavioural_constrains.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using LinearAlgebra
 using Random
 using RobustNeuralNetworks

--- a/test/ParameterTypes/lipschitz_bound.jl
+++ b/test/ParameterTypes/lipschitz_bound.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using Random
 using RobustNeuralNetworks
 using Test

--- a/test/ParameterTypes/passivity.jl
+++ b/test/ParameterTypes/passivity.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using LinearAlgebra
 using Random
 using RobustNeuralNetworks

--- a/test/Wrappers/diff_lbdn.jl
+++ b/test/Wrappers/diff_lbdn.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using Flux
 using Random
 using RobustNeuralNetworks

--- a/test/Wrappers/diff_ren.jl
+++ b/test/Wrappers/diff_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using Flux
 using Random
 using RobustNeuralNetworks

--- a/test/Wrappers/wrap_ren.jl
+++ b/test/Wrappers/wrap_ren.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using LinearAlgebra
 using Random
 using RobustNeuralNetworks

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 using RobustNeuralNetworks
 using Test
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,3 +1,5 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
 """
 Compute P for any REN
 """


### PR DESCRIPTION
A comment in every source file was entered at the top of the file referencing the license used in this project #82