### PR TITLE
Bugfix for Linear RENs and Type Stability

### DIFF
--- a/src/ParameterTypes/general_ren.jl
+++ b/src/ParameterTypes/general_ren.jl
@@ -150,7 +150,7 @@ function direct_to_explicit(ps::GeneralRENParams{T}, return_h=false) where T
 
     𝑅 = R + S*D22 + D22'*S' + D22'*Q*D22
 
-    Γ1 = [C2'; D21'; zeros(nx, ny)] * Q * [C2 D21 zeros(ny, nx)]
+    Γ1 = [C2'; D21'; zeros(T, nx, ny)] * Q * [C2 D21 zeros(T, ny, nx)]
     Γ2 = [C2_imp'; D21_imp'; B2_imp] * (𝑅 \ [C2_imp D21_imp B2_imp'])
 
     H = x_to_h(X, ϵ, polar_param, ρ) + Γ2 - Γ1

--- a/src/ParameterTypes/lipschitz_ren.jl
+++ b/src/ParameterTypes/lipschitz_ren.jl
@@ -129,7 +129,7 @@ function direct_to_explicit(ps::LipschitzRENParams{T}, return_h=false) where T
 
     𝑅 = -D22'*D22 / γ + (γ * I)
 
-    Γ1 = [C2'; D21'; zeros(nx, ny)] * [C2 D21 zeros(ny, nx)] * (-1/γ)
+    Γ1 = [C2'; D21'; zeros(T, nx, ny)] * [C2 D21 zeros(T, ny, nx)] * (-1/γ)
     Γ2 = [C2_imp'; D21_imp'; B2_imp] * (𝑅 \ [C2_imp D21_imp B2_imp'])
 
     H = x_to_h(X, ϵ, polar_param, ρ) + Γ2 - Γ1

--- a/src/ParameterTypes/utils.jl
+++ b/src/ParameterTypes/utils.jl
@@ -98,3 +98,42 @@ end
 function x_to_h(X::AbstractMatrix{T}, ϵ::T, polar_param::Bool, ρ::T) where T
     polar_param ? (ρ^2)*(X'*X) / norm(X)^2 + ϵ*I : X'*X + ϵ*I
 end
+
+"""
+    set_output_zero!(m::AbstractRENParams)
+
+Set output map of a REN to zero.
+
+If the resulting model is called with
+```julia
+ren = REN(m)
+x1, y = ren(x, u)
+```
+then `y = 0` for any `x` and `u`.
+"""
+function set_output_zero!(m::AbstractRENParams)
+    m.direct.C2  .= 0
+    m.direct.D21 .= 0
+    m.direct.D22 .= 0
+    m.direct.by  .= 0
+    return nothing
+end
+
+"""
+    set_output_zero!(m::AbstractLBDNParams)
+
+Set output map of an LBDN to zero.
+
+If the resulting model is called with 
+```julia
+lbdn = LBDN(m)
+y = lbdn(u)
+```
+then `y = 0` for any `u`.
+"""
+function set_output_zero!(m::AbstractLBDNParams)
+    m.direct.XY[end][(m.ny+1):end,:] .= 0
+    m.direct.b[end] .= 0
+
+    return nothing
+end

--- a/src/ParameterTypes/utils.jl
+++ b/src/ParameterTypes/utils.jl
@@ -47,6 +47,7 @@ function hmatrix_to_explicit(ps::AbstractRENParams, H::AbstractMatrix{T}, D22::A
     # System sizes
     nx = ps.nx
     nv = ps.nv
+    nu = ps.nu
 
     # To be used later
     ᾱ = ps.αbar
@@ -77,9 +78,9 @@ function hmatrix_to_explicit(ps::AbstractRENParams, H::AbstractMatrix{T}, D22::A
     B1 = E \ B1_imp
     B2 = E \ ps.direct.B2
 
-    C1 = broadcast(*, Λ_inv, C1_imp)
-    D11 = broadcast(*, Λ_inv, D11_imp)
-    D12 = broadcast(*, Λ_inv, ps.direct.D12)
+    C1  = (nv == 0) ? zeros(T,0,nx) : broadcast(*, Λ_inv, C1_imp)
+    D11 = (nv == 0) ? zeros(T,0,0)  : broadcast(*, Λ_inv, D11_imp)
+    D12 = (nv == 0) ? zeros(T,0,nu) : broadcast(*, Λ_inv, ps.direct.D12)
 
     C2 = ps.direct.C2
     D21 = ps.direct.D21

--- a/src/Wrappers/LBDN/diff_lbdn.jl
+++ b/src/Wrappers/LBDN/diff_lbdn.jl
@@ -43,3 +43,7 @@ function (m::DiffLBDN)(u::AbstractVecOrMat)
 end
 
 Flux.@functor DiffLBDN (params, )
+
+function set_output_zero!(m::DiffLBDN)
+    set_output_zero!(m.params)
+end

--- a/src/Wrappers/LBDN/lbdn.jl
+++ b/src/Wrappers/LBDN/lbdn.jl
@@ -90,16 +90,9 @@ function (m::AbstractLBDN{T})(u::AbstractVecOrMat, explicit::ExplicitLBDNParams{
     return sqrtγ * B[N] * h .+ b[N]
 end
 
-"""
-    set_output_zero!(m::AbstractLBDN)
-
-Set output map of an LBDN to zero.
-
-If the resulting model is called with `y = lbdn(u)` then `y = 0` for any `u`.
-"""
 function set_output_zero!(m::AbstractLBDN)
-    m.explicit.B[end] .*= 0
-    m.explicit.b[end] .*= 0
+    m.explicit.B[end] .= 0
+    m.explicit.b[end] .= 0
 
     return nothing
 end

--- a/src/Wrappers/REN/diff_ren.jl
+++ b/src/Wrappers/REN/diff_ren.jl
@@ -44,3 +44,7 @@ function (m::DiffREN)(xt::AbstractVecOrMat, ut::AbstractVecOrMat)
     explicit = direct_to_explicit(m.params)
     return m(xt, ut, explicit) 
 end
+
+function set_output_zero!(m::DiffREN)
+    set_output_zero!(m.params)
+end

--- a/src/Wrappers/REN/ren.jl
+++ b/src/Wrappers/REN/ren.jl
@@ -98,18 +98,11 @@ function init_states(m::AbstractREN{T}; rng=nothing) where T
     return zeros(T, m.nx)
 end
 
-"""
-    set_output_zero!(m::AbstractREN)
-
-Set output map of a REN to zero.
-
-If the resulting model is called with `x1,y = ren(x,u)` then `y = 0` for any `x` and `u`.
-"""
 function set_output_zero!(m::AbstractREN)
-    m.explicit.C2 .*= 0
-    m.explicit.D21 .*= 0
-    m.explicit.D22 .*= 0
-    m.explicit.by .*= 0
+    m.explicit.C2  .= 0
+    m.explicit.D21 .= 0
+    m.explicit.D22 .= 0
+    m.explicit.by  .= 0
 
     return nothing
 end

--- a/test/Wrappers/diff_lbdn.jl
+++ b/test/Wrappers/diff_lbdn.jl
@@ -13,7 +13,7 @@ Test that backpropagation runs and parameters change
 batches = 10
 nu, ny, γ = 2, 3, 1
 nh = [10,5]
-model_ps = DenseLBDNParams{Float64}(nu, nh, ny, γ; learn_γ=true)
+model_ps = DenseLBDNParams{Float32}(nu, nh, ny, γ; learn_γ=true)
 model = DiffLBDN(model_ps)
 
 # Dummy data

--- a/test/Wrappers/diff_ren.jl
+++ b/test/Wrappers/diff_ren.jl
@@ -13,7 +13,7 @@ Test that backpropagation runs and parameters change
 batches = 10
 nu, nx, nv, ny = 4, 5, 10, 3
 γ = 10
-ren_ps = LipschitzRENParams{Float64}(nu, nx, nv, ny, γ)
+ren_ps = LipschitzRENParams{Float32}(nu, nx, nv, ny, γ)
 model = DiffREN(ren_ps)
 
 # Dummy data


### PR DESCRIPTION
Bugfixes:

- Fixed error arising when taking gradients with `nv = 0` (i.e: a linear REN).
- Fixed issues with type stability in `LipschitzRENParams` and `GeneralRENParams`.
- Added further methods for `set_output_zero!()`