### PR TITLE
Bugfix: error when taking gradients with `nv = 0` or `nx = 0`

### DIFF
--- a/src/ParameterTypes/utils.jl
+++ b/src/ParameterTypes/utils.jl
@@ -78,6 +78,7 @@ function hmatrix_to_explicit(ps::AbstractRENParams, H::AbstractMatrix{T}, D22::A
     B1 = E \ B1_imp
     B2 = E \ ps.direct.B2
 
+    # Current versions of Julia behave poorly when broadcasting over 0-dim arrays
     C1  = (nv == 0) ? zeros(T,0,nx) : broadcast(*, Λ_inv, C1_imp)
     D11 = (nv == 0) ? zeros(T,0,0)  : broadcast(*, Λ_inv, D11_imp)
     D12 = (nv == 0) ? zeros(T,0,nu) : broadcast(*, Λ_inv, ps.direct.D12)

--- a/src/RobustNeuralNetworks.jl
+++ b/src/RobustNeuralNetworks.jl
@@ -6,7 +6,7 @@ module RobustNeuralNetworks
 
 using Flux
 using LinearAlgebra
-using MatrixEquations: lyapd, plyapd
+using MatrixEquations: lyapd
 using Random
 using Zygote: pullback, Buffer
 using Zygote: @adjoint

--- a/src/Wrappers/REN/ren.jl
+++ b/src/Wrappers/REN/ren.jl
@@ -77,9 +77,14 @@ function (m::AbstractREN{T})(
     explicit::ExplicitRENParams{T}
 ) where T
 
-    b = explicit.C1 * xt + explicit.D12 * ut .+ explicit.bv
+    # Allocate bias vectors to avoid error when nv = 0 or nx = 0
+    # TODO: if statement (or equivalent) makes backpropagation slower. Can we avoid this?
+    bv = (m.nv == 0) ? 0 : explicit.bv
+    bx = (m.nx == 0) ? 0 : explicit.bx
+
+    b = explicit.C1 * xt + explicit.D12 * ut .+ bv
     wt = tril_eq_layer(m.nl, explicit.D11, b)
-    xt1 = explicit.A * xt + explicit.B1 * wt + explicit.B2 * ut .+ explicit.bx
+    xt1 = explicit.A * xt + explicit.B1 * wt + explicit.B2 * ut .+ bx
     yt = explicit.C2 * xt + explicit.D21 * wt + explicit.D22 * ut .+ explicit.by
 
     return xt1, yt

--- a/test/Wrappers/diff_lbdn.jl
+++ b/test/Wrappers/diff_lbdn.jl
@@ -5,8 +5,6 @@ using Random
 using RobustNeuralNetworks
 using Test
 
-# include("../test_utils.jl")
-
 """
 Test that backpropagation runs and parameters change
 """

--- a/test/Wrappers/diff_ren.jl
+++ b/test/Wrappers/diff_ren.jl
@@ -11,7 +11,7 @@ using Test
 Test that backpropagation runs and parameters change
 """
 batches = 10
-nu, nx, nv, ny = 1, 10, 0, 1
+nu, nx, nv, ny = 4, 5, 10, 2
 γ = 10
 model_ps = LipschitzRENParams{Float32}(nu, nx, nv, ny, γ)
 

--- a/test/Wrappers/diff_ren.jl
+++ b/test/Wrappers/diff_ren.jl
@@ -5,21 +5,20 @@ using Random
 using RobustNeuralNetworks
 using Test
 
-include("../test_utils.jl")
+# include("../test_utils.jl")
 
 """
 Test that backpropagation runs and parameters change
 """
 batches = 10
-nu, nx, nv, ny = 4, 5, 0, 2
-γ = 10
+nu, nx, nv, ny, γ = 4, 5, 0, 2, 10
 ren_ps = LipschitzRENParams{Float64}(nu, nx, nv, ny, γ)
 model = DiffREN(ren_ps)
 
 # Dummy data
 us = randn(nu, batches)
 ys = randn(ny, batches)
-data = [(us[:,k], ys[:,k]) for k in 1:batches]
+data = [(us, ys)]
 
 # Dummy loss function just for testing
 function loss(m, u, y)
@@ -31,7 +30,6 @@ end
 # Debug batch updates
 opt_state = Flux.setup(Adam(0.01), model)
 gs = Flux.gradient(loss, model, us, ys)
-Flux.update!(opt_state, model, gs[1])
 println()
 
 # # Check if parameters change after a Flux update

--- a/test/Wrappers/diff_ren.jl
+++ b/test/Wrappers/diff_ren.jl
@@ -5,15 +5,16 @@ using Random
 using RobustNeuralNetworks
 using Test
 
-# include("../test_utils.jl")
+include("../test_utils.jl")
 
 """
 Test that backpropagation runs and parameters change
 """
 batches = 10
-nu, nx, nv, ny = 4, 5, 10, 2
+nu, nx, nv, ny = 4, 5, 0, 2
 γ = 10
-model_ps = LipschitzRENParams{Float32}(nu, nx, nv, ny, γ)
+ren_ps = LipschitzRENParams{Float64}(nu, nx, nv, ny, γ)
+model = DiffREN(ren_ps)
 
 # Dummy data
 us = randn(nu, batches)
@@ -21,17 +22,22 @@ ys = randn(ny, batches)
 data = [(us[:,k], ys[:,k]) for k in 1:batches]
 
 # Dummy loss function just for testing
-function loss(model_ps, u, y)
-    m = DiffREN(model_ps)
+function loss(m, u, y)
     x0 = init_states(m, size(u,2))
     x1, y1 = m(x0, u)
     return Flux.mse(y1, y) + sum(x1.^2)
 end
 
-# Check if parameters change after a Flux update
-ps1 = deepcopy(Flux.params(model_ps))
-opt_state = Flux.setup(Adam(0.01), model_ps)
-Flux.train!(loss, model_ps, data, opt_state)
-ps2 = Flux.params(model_ps)
+# Debug batch updates
+opt_state = Flux.setup(Adam(0.01), model)
+gs = Flux.gradient(loss, model, us, ys)
+Flux.update!(opt_state, model, gs[1])
+println()
 
-@test !any(ps1 .≈ ps2)
+# # Check if parameters change after a Flux update
+# ps1 = deepcopy(Flux.params(model))
+# opt_state = Flux.setup(Adam(0.01), model)
+# Flux.train!(loss, model, data, opt_state)
+# ps2 = Flux.params(model)
+
+# @test !any(ps1 .≈ ps2)

--- a/test/Wrappers/diff_ren.jl
+++ b/test/Wrappers/diff_ren.jl
@@ -11,10 +11,9 @@ using Test
 Test that backpropagation runs and parameters change
 """
 batches = 10
-nu, nx, nv, ny = 4, 5, 10, 3
+nu, nx, nv, ny = 1, 10, 0, 1
 γ = 10
-ren_ps = LipschitzRENParams{Float32}(nu, nx, nv, ny, γ)
-model = DiffREN(ren_ps)
+model_ps = LipschitzRENParams{Float32}(nu, nx, nv, ny, γ)
 
 # Dummy data
 us = randn(nu, batches)
@@ -22,16 +21,17 @@ ys = randn(ny, batches)
 data = [(us[:,k], ys[:,k]) for k in 1:batches]
 
 # Dummy loss function just for testing
-function loss(m, u, y)
+function loss(model_ps, u, y)
+    m = DiffREN(model_ps)
     x0 = init_states(m, size(u,2))
     x1, y1 = m(x0, u)
     return Flux.mse(y1, y) + sum(x1.^2)
 end
 
 # Check if parameters change after a Flux update
-ps1 = deepcopy(Flux.params(model))
-opt_state = Flux.setup(Adam(0.01), model)
-Flux.train!(loss, model, data, opt_state)
-ps2 = Flux.params(model)
+ps1 = deepcopy(Flux.params(model_ps))
+opt_state = Flux.setup(Adam(0.01), model_ps)
+Flux.train!(loss, model_ps, data, opt_state)
+ps2 = Flux.params(model_ps)
 
 @test !any(ps1 .≈ ps2)

--- a/test/Wrappers/zero_dim.jl
+++ b/test/Wrappers/zero_dim.jl
@@ -5,18 +5,19 @@ using Random
 using RobustNeuralNetworks
 using Test
 
-# include("../test_utils.jl")
-
 function (m::AbstractREN{T})(
     xt::AbstractVecOrMat, 
     ut::AbstractVecOrMat,
     explicit::ExplicitRENParams{T}
 ) where T
 
-    println("testing")
-    b = explicit.C1 * xt + explicit.D12 * ut .+ explicit.bv
+    # Allocate bias vectors to avoid error when nv = 0 or nx = 0
+    bv = (m.nv == 0) ? 0 : explicit.bv
+    bx = (m.nx == 0) ? 0 : explicit.bx
+
+    b = explicit.C1 * xt + explicit.D12 * ut .+ bv
     wt = RobustNeuralNetworks.tril_eq_layer(m.nl, explicit.D11, b)
-    xt1 = explicit.A * xt + explicit.B1 * wt + explicit.B2 * ut .+ explicit.bx
+    xt1 = explicit.A * xt + explicit.B1 * wt + explicit.B2 * ut .+ bx
     yt = explicit.C2 * xt + explicit.D21 * wt + explicit.D22 * ut .+ explicit.by
 
     return xt1, yt
@@ -26,9 +27,9 @@ end
 Test that backpropagation runs and parameters change
 """
 batches = 10
-nu, nx, nv, ny, γ = 4, 5, 0, 2, 10
-ren_ps = LipschitzRENParams{Float64}(nu, nx, nv, ny, γ)
-model = DiffREN(ren_ps)
+nu, nx, nv, ny = 4, 0, 0, 2
+γ = 10
+model_ps = LipschitzRENParams{Float64}(nu, nx, nv, ny, γ)
 
 # Dummy data
 us = randn(nu, batches)
@@ -36,21 +37,23 @@ ys = randn(ny, batches)
 data = [(us, ys)]
 
 # Dummy loss function just for testing
-function loss(m, u, y)
+function loss(model_ps, u, y)
+    m = REN(model_ps)
     x0 = init_states(m, size(u,2))
     x1, y1 = m(x0, u)
     return Flux.mse(y1, y) + sum(x1.^2)
 end
 
-# Debug batch updates
+# Test it
+model = REN(model_ps);
+x0 = init_states(model, batches)
+
+# @btime model(x0, us)
+# @btime Flux.gradient(loss, model_ps, us, ys)
+# println()
+
+# Make sure batch update actually runs
 opt_state = Flux.setup(Adam(0.01), model)
 gs = Flux.gradient(loss, model, us, ys)
-println()
-
-# # Check if parameters change after a Flux update
-# ps1 = deepcopy(Flux.params(model))
-# opt_state = Flux.setup(Adam(0.01), model)
-# Flux.train!(loss, model, data, opt_state)
-# ps2 = Flux.params(model)
-
-# @test !any(ps1 .≈ ps2)
+Flux.update!(opt_state, model, gs[1])
+@test !isempty(gs)

--- a/test/Wrappers/zero_dim.jl
+++ b/test/Wrappers/zero_dim.jl
@@ -1,0 +1,56 @@
+# This file is a part of RobustNeuralNetworks.jl. License is MIT: https://github.com/acfr/RobustNeuralNetworks.jl/blob/main/LICENSE 
+
+using Flux
+using Random
+using RobustNeuralNetworks
+using Test
+
+# include("../test_utils.jl")
+
+function (m::AbstractREN{T})(
+    xt::AbstractVecOrMat, 
+    ut::AbstractVecOrMat,
+    explicit::ExplicitRENParams{T}
+) where T
+
+    println("testing")
+    b = explicit.C1 * xt + explicit.D12 * ut .+ explicit.bv
+    wt = RobustNeuralNetworks.tril_eq_layer(m.nl, explicit.D11, b)
+    xt1 = explicit.A * xt + explicit.B1 * wt + explicit.B2 * ut .+ explicit.bx
+    yt = explicit.C2 * xt + explicit.D21 * wt + explicit.D22 * ut .+ explicit.by
+
+    return xt1, yt
+end
+
+"""
+Test that backpropagation runs and parameters change
+"""
+batches = 10
+nu, nx, nv, ny, γ = 4, 5, 0, 2, 10
+ren_ps = LipschitzRENParams{Float64}(nu, nx, nv, ny, γ)
+model = DiffREN(ren_ps)
+
+# Dummy data
+us = randn(nu, batches)
+ys = randn(ny, batches)
+data = [(us, ys)]
+
+# Dummy loss function just for testing
+function loss(m, u, y)
+    x0 = init_states(m, size(u,2))
+    x1, y1 = m(x0, u)
+    return Flux.mse(y1, y) + sum(x1.^2)
+end
+
+# Debug batch updates
+opt_state = Flux.setup(Adam(0.01), model)
+gs = Flux.gradient(loss, model, us, ys)
+println()
+
+# # Check if parameters change after a Flux update
+# ps1 = deepcopy(Flux.params(model))
+# opt_state = Flux.setup(Adam(0.01), model)
+# Flux.train!(loss, model, data, opt_state)
+# ps2 = Flux.params(model)
+
+# @test !any(ps1 .≈ ps2)

--- a/test/Wrappers/zero_dim.jl
+++ b/test/Wrappers/zero_dim.jl
@@ -5,26 +5,8 @@ using Random
 using RobustNeuralNetworks
 using Test
 
-function (m::AbstractREN{T})(
-    xt::AbstractVecOrMat, 
-    ut::AbstractVecOrMat,
-    explicit::ExplicitRENParams{T}
-) where T
-
-    # Allocate bias vectors to avoid error when nv = 0 or nx = 0
-    bv = (m.nv == 0) ? 0 : explicit.bv
-    bx = (m.nx == 0) ? 0 : explicit.bx
-
-    b = explicit.C1 * xt + explicit.D12 * ut .+ bv
-    wt = RobustNeuralNetworks.tril_eq_layer(m.nl, explicit.D11, b)
-    xt1 = explicit.A * xt + explicit.B1 * wt + explicit.B2 * ut .+ bx
-    yt = explicit.C2 * xt + explicit.D21 * wt + explicit.D22 * ut .+ explicit.by
-
-    return xt1, yt
-end
-
 """
-Test that backpropagation runs and parameters change
+Test that backpropagation runs when nx = 0 and nv = 0
 """
 batches = 10
 nu, nx, nv, ny = 4, 0, 0, 2
@@ -44,16 +26,8 @@ function loss(model_ps, u, y)
     return Flux.mse(y1, y) + sum(x1.^2)
 end
 
-# Test it
-model = REN(model_ps);
-x0 = init_states(model, batches)
-
-# @btime model(x0, us)
-# @btime Flux.gradient(loss, model_ps, us, ys)
-# println()
-
 # Make sure batch update actually runs
-opt_state = Flux.setup(Adam(0.01), model)
-gs = Flux.gradient(loss, model, us, ys)
-Flux.update!(opt_state, model, gs[1])
+opt_state = Flux.setup(Adam(0.01), model_ps)
+gs = Flux.gradient(loss, model_ps, us, ys)
+Flux.update!(opt_state, model_ps, gs[1])
 @test !isempty(gs)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,5 +20,6 @@ using Test
     include("Wrappers/wrap_ren.jl")
     include("Wrappers/diff_ren.jl")
     include("Wrappers/diff_lbdn.jl")
+    include("Wrappers/zero_dim.jl")
 
 end


### PR DESCRIPTION
Fixed errors arising when using `Flux.gradient()` with a REN that has `nx = 0` and/or `nv = 0`. The error was due to broadcasting over zero-dimensional arrays. Added a test to check for future issues.