### PR TITLE
Feature/rand init

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ println(round.(y1;digits=2))
 The output should be:
 
 ```julia
-[-1.1 0.32 0.27 0.14 -1.23 -0.4 -0.7 0.01 0.19 0.81]
+[1.38 0.56 0.89 2.11 2.14 0.89 1.63 0.44 1.24 1.26]
 ```
 
 ## Citing the Package

--- a/docs/src/introduction/getting_started.md
+++ b/docs/src/introduction/getting_started.md
@@ -38,7 +38,7 @@ println(round.(y1; digits=2))
 
 # output
 
-[0.23 -0.01 -0.06 0.15 -0.03 -0.11 0.0 0.42 0.24 0.22]
+[0.98 1.24 0.86 1.93 1.08 1.19 1.23 1.4 0.95 0.65]
 ```
 
 For detailed examples of training models from `RobustNeuralNetworks.jl`, we recommend starting with [Fitting a Curve with LBDN](@ref) and working through the subsequent examples.

--- a/src/Base/ren_params.jl
+++ b/src/Base/ren_params.jl
@@ -83,7 +83,8 @@ This is typically used by higher-level constructors when defining a REN, which t
 # Keyword arguments
 
 - `init=:random`: Initialisation method. Options are:
-    - `:random`: Random sampling for all parameters.
+    - `:random`: Random sampling with Glorot normal distribution.
+    - `:randomQR:` Compute `X` with `glorot_normal` and take the QR decomposition `X = qr(X).Q`. Good for initialising `X` close to the identity when long memory is needed.
     - `:cholesky`: Compute `X` with cholesky factorisation of `H`, sets `E,F,P = I`.
 
 - `polar_param::Bool=true`: Use polar parameterisation to construct `H` matrix from `X` in REN parameterisation (recommended).
@@ -138,11 +139,18 @@ function DirectRENParams{T}(
 
         B2  = glorot_normal(nx, nu; T, rng)
         D12 = glorot_normal(nv, nu; T, rng)
+        X   = glorot_normal(2nx + nv, 2nx + nv; T, rng)
+
+    # Random sampling with QR factorisation
+    elseif init == :randomQR
+
+        B2  = glorot_normal(nx, nu; T, rng)
+        D12 = glorot_normal(nv, nu; T, rng)
         
         # Make orthogonal X
         X = glorot_normal(2nx + nv, 2nx + nv; T, rng)
         X = Matrix(qr(X).Q)
-
+    
     # Specify H and compute X
     elseif init == :cholesky
 
@@ -158,7 +166,7 @@ function DirectRENParams{T}(
         D12 = zeros(T, nv, nu)
 
         # TODO: This is prone to errors. Needs a bugfix!
-        Λ = 2*I
+        Λ = 2.5*I
         H22 = 2Λ - D11 - D11'
         Htild = [(E + E' - P) -C1' F';
                  -C1 H22 B1'

--- a/src/Base/ren_params.jl
+++ b/src/Base/ren_params.jl
@@ -82,10 +82,10 @@ This is typically used by higher-level constructors when defining a REN, which t
     
 # Keyword arguments
 
-- `init=:random`: Initialisation method. Options are:
-    - `:random`: Random sampling with Glorot normal distribution.
-    - `:randomQR:` Compute `X` with `glorot_normal` and take the QR decomposition `X = qr(X).Q`. Good for initialising `X` close to the identity when long memory is needed.
-    - `:cholesky`: Compute `X` with cholesky factorisation of `H`, sets `E,F,P = I`.
+- `init=:randomQR`: Initialisation method. Options are:
+    - `:random`: Random sampling with Glorot normal distribution. Typically samples "faster"/short memory dynamic models.
+    - `:randomQR:` Compute `X` with `glorot_normal` and take the QR decomposition `X = qr(X).Q`. Good for initialising `X` close to the identity when long memory is needed. Default as legacy.
+    - `:cholesky`: Compute `X` with cholesky factorisation of `H`, sets `E,F,P = I`. Good for slow/long memory dynamic models.
 
 - `polar_param::Bool=true`: Use polar parameterisation to construct `H` matrix from `X` in REN parameterisation (recommended).
 
@@ -109,7 +109,7 @@ See also [`GeneralRENParams`](@ref), [`ContractingRENParams`](@ref), [`Lipschitz
 """
 function DirectRENParams{T}(
     nu::Int, nx::Int, nv::Int, ny::Int; 
-    init                = :random,
+    init                = :randomQR,
     polar_param::Bool   = true,
     D22_free::Bool      = false,
     D22_zero::Bool      = false,

--- a/src/Base/utils.jl
+++ b/src/Base/utils.jl
@@ -6,6 +6,6 @@
 Generate matrices or vectors from the Glorot normal distribution.
 """
 glorot_normal(n::Int, m::Int; T=Float64, rng=Random.GLOBAL_RNG) = 
-    convert.(T, randn(rng, n, m) / sqrt(n + m))
+    convert.(T, Flux.glorot_normal(rng, n, m))
 glorot_normal(n::Int; T=Float64, rng=Random.GLOBAL_RNG) = 
-    convert.(T, randn(rng, n) / sqrt(n))
+    convert.(T, Flux.glorot_normal(rng, n))

--- a/src/Wrappers/REN/ren.jl
+++ b/src/Wrappers/REN/ren.jl
@@ -62,7 +62,7 @@ println(round.(y1;digits=2))
 
 # output
 
-[-1.1 0.32 0.27 0.14 -1.23 -0.4 -0.7 0.01 0.19 0.81]
+[1.38 0.56 0.89 2.11 2.14 0.89 1.63 0.44 1.24 1.26]
 ```
 
 See also [`REN`](@ref), [`WrapREN`](@ref), and [`DiffREN`](@ref).

--- a/src/Wrappers/REN/wrap_ren.jl
+++ b/src/Wrappers/REN/wrap_ren.jl
@@ -56,7 +56,7 @@ println(round(ren.explicit.B2[10];digits=4))
 
 # output
 
-0.0109
+0.0051
 ```
 
 See also [`AbstractREN`](@ref), [`REN`](@ref), and [`DiffREN`](@ref).


### PR DESCRIPTION
Updated initialisation of RENs:
- Changed to `Flux.glorot_normal` for consistency
- Separated `:random` initialisation from `:randomQR` initialisation with QR decomposition.